### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ A [Model Context Protocol](https://github.com/modelcontextprotocol) server for t
 > [!WARNING]
 > This is highly experimental and use at your own risk.
 
+<a href="https://glama.ai/mcp/servers/c7fgtnckbv">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/c7fgtnckbv/badge" alt="Inkdrop Server MCP server" />
+</a>
+
 ## Installation
 
 1. [Set up a local HTTP server](https://developers.inkdrop.app/guides/access-the-local-database#accessing-via-http-advanced)
@@ -24,7 +28,7 @@ A [Model Context Protocol](https://github.com/modelcontextprotocol) server for t
       ],
       "env": {
         "INKDROP_LOCAL_SERVER_URL": "http://localhost:19840",
-        "INKDROP_LOCAL_USERNAME": "your-local-server-username"
+        "INKDROP_LOCAL_USERNAME": "your-local-server-username",
         "INKDROP_LOCAL_PASSWORD": "your-local-server-password"
       }
     }


### PR DESCRIPTION
This PR adds a badge for the [Inkdrop MCP Server](https://glama.ai/mcp/servers/c7fgtnckbv) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/c7fgtnckbv">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/c7fgtnckbv/badge" alt="Inkdrop Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.